### PR TITLE
Specify a list of fallback resources

### DIFF
--- a/t/004-fallback-resource.t
+++ b/t/004-fallback-resource.t
@@ -1,0 +1,54 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Fatal;
+
+use Plack::Request;
+use Plack::Response;
+
+BEGIN {
+    use_ok('Web::Machine');
+}
+
+{
+    package Good::Resource;
+    use strict;
+    use warnings;
+
+    use parent 'Web::Machine::Resource';
+
+    sub content_types_provided { [{ 'text/html' => 'to_html' }] }
+
+    sub to_html { '<html><body>Hello World</body></html>' }
+}
+
+{
+    package Bad::Resource;
+    use strict;
+    use warnings;
+
+    use parent 'Web::Machine::Resource';
+
+    sub new {
+      die "Something broke";
+    }
+}
+
+my $app = Web::Machine->new(
+    resource => [qw/ Bad::Resource Good::Resource / ],
+)->to_app;
+
+my $env = {
+           REQUEST_METHOD    => 'GET',
+           SERVER_PROTOCOL   => 'HTTP/1.1',
+           SERVER_NAME       => 'example.com',
+           SCRIPT_NAME       => '/foo',
+          };
+
+
+ok my $resp = $app->($env), 'created resource';
+
+done_testing;


### PR DESCRIPTION
This change allows you to specify a list of resources.

This can be used to provide a fallback if a resource fails. See https://github.com/stevan/webmachine-perl/issues/26 for a description of one use case.