### PR TITLE
store acceptable request handler in metadata

### DIFF
--- a/lib/Web/Machine/FSM/States.pm
+++ b/lib/Web/Machine/FSM/States.pm
@@ -65,10 +65,15 @@ sub _ensure_quoted_header {
 
 sub _get_acceptable_content_type_handler {
     my ($resource, $request) = @_;
-    my $acceptable = match_acceptable_media_type(
-        ($request->header('Content-Type') || 'application/octet-stream'),
-        $resource->content_types_accepted
-    );
+    my $metadata = _metadata($request);
+    my $acceptable = $metadata->{'acceptable_request_handler'};
+    if ( not defined $acceptable ) {
+        $acceptable = match_acceptable_media_type(
+            ($request->header('Content-Type') || 'application/octet-stream'),
+            $resource->content_types_accepted
+        );
+        $metadata->{'acceptable_request_handler'} = $acceptable;
+    } 
     return \415 unless $acceptable;
     return pair_value( $acceptable );
 }


### PR DESCRIPTION
Hi guys, further to https://rt.cpan.org/Public/Bug/Display.html?id=101203 here is a patch that stores the acceptable request handler in the metadata to reduce the number of calls to 'content_types_accepted'.

Although 'content_types_accepted' can be assumed to be idempotent, I believe this change is needed because Web::Machine does not call the request handler when 'post_is_create' is false. Instead, it calls 'process_post', which I have to implement myself. There I would like to call the acceptable request handler (which has been known since B5), except I can't because - without this patch - I have no way of knowing what the acceptable request handler is.